### PR TITLE
Fix order of calculations for nanoseconds to seconds conversion on Mac

### DIFF
--- a/src/mac/idle.cc
+++ b/src/mac/idle.cc
@@ -17,7 +17,7 @@ int32_t SystemIdleTime(void) {
         if (obj) {
           int64_t nanoseconds = 0;
           if (CFNumberGetValue(obj, kCFNumberSInt64Type, &nanoseconds)) {
-            idlesecs = (int32_t) (nanoseconds / 1000L*1000L);
+            idlesecs = (int32_t) (nanoseconds / (1000L*1000L));
           }
         }
         CFRelease(dict);


### PR DESCRIPTION
Before this change, the nanoseconds were being divided by 1000 and subsequently multiplied by 1000, returning the nanoseconds. This overflows every few seconds in an int32.