### PR TITLE
Update for more current version of node.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,7 @@
           "src/mac/idle.cc"
         ],
         "xcode_settings": {
-          "OTHER_CPLUSPLUSFLAGS": ["-std=c++11", "-stdlib=libc++", "-mmacosx-version-min=10.7"],
+          "OTHER_CPLUSPLUSFLAGS": ["-std=c++11", "-stdlib=libc++"],
           "OTHER_LDFLAGS": ["-framework CoreFoundation -framework IOKit"]
         }
       }],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-system-idle-time",
+  "name": "system-idle-time",
   "version": "1.0.2",
   "description": "Returns system idle time in seconds",
   "main": "addon.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@paulcbetts/system-idle-time",
+  "name": "node-system-idle-time",
   "version": "1.0.2",
   "description": "Returns system idle time in seconds",
   "main": "addon.js",


### PR DESCRIPTION
This fixes an issue with newer version of node js. Since iojs is now built into node we do not need to reference iojs as a separate entity. This also fixes an issue on newer windows system when compiling with electron.