### PR TITLE
Add context-aware support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "gypfile": true,
   "homepage": "https://bitbucket.org/rbergman/system-idle-time#readme",
   "dependencies": {
-    "nan": "^2.0.0",
-    "bindings": "~1.2.1"
+    "bindings": "~1.2.1",
+    "nan": "^2.14.0"
   }
 }

--- a/src/module.cc
+++ b/src/module.cc
@@ -11,8 +11,12 @@ NAN_METHOD(IdleTime::GetIdleTime) {
   info.GetReturnValue().Set(idle);
 }
 
-void IdleTime::Init(Local<Object> exports) {
-  Nan::SetMethod(exports, "getIdleTime", IdleTime::GetIdleTime);
+NAN_MODULE_INIT(Init) {
+  Nan::SetMethod(target, "getIdleTime", IdleTime::GetIdleTime);
 }
 
-NODE_MODULE(system_idle_time, IdleTime::Init)
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(system_idle_time, Init)
+#else
+NODE_MODULE(system_idle_time, Init)
+#endif


### PR DESCRIPTION
This allows the module to build as a [context-aware addon](https://nodejs.org/api/addons.html#addons_context_aware_addons) if the user has NodeJS 10 or greater.

This work was done per [Electron's deprecation message about non context-aware modules](https://github.com/electron/electron/issues/18397). The work is [patterned off of this PR for `node-keytar`](https://github.com/atom/node-keytar/pull/182/files).

I don't think any extra cleanup code needs to be added, but it _may_ need to be used for the Linux code. I'm not an expert in that area, though.